### PR TITLE
Release 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simplifies the deployment and management of ArgoCD on a Kubernetes cluster.
 **New in `v1.0.0`:**
 * No longer relies on the `banzaicloud/k8s` provider.
 * Can be deployed alongside any ingress controller.
-* Deployable with or without SSL (if you're into that kind of thing...)
+* Deployable without SSL (if you're into that kind of thing...)
 * This module no longer relies on external modules.
 
 ---

--- a/argocd-config-maps.tf
+++ b/argocd-config-maps.tf
@@ -27,15 +27,13 @@ resource "kubernetes_config_map" "argocd_cm" {
     }, var.labels)
   }
   data = {
-    url                       = "https://${var.argocd_url}"
+    url                       = "https://${var.ingress_host}${var.ingress_path}"
     "oidc.config"             = var.oidc_config != null ? yamlencode(local.oidc_config) : null
     "repositories"            = yamlencode(var.argocd_repositories),
     "repository.credentials"  = yamlencode(var.argocd_repository_credentials)
     "resource.customizations" = templatefile("${path.module}/configuration-files/resource-customizations.yml", {})
   }
 }
-
-
 
 resource "kubernetes_config_map" "argocd_gpg_keys_cm" {
   metadata {

--- a/argocd-custom-resource-definitions.tf
+++ b/argocd-custom-resource-definitions.tf
@@ -1,7 +1,7 @@
-resource "k8s_manifest" "applications" {
-  content = templatefile("${path.module}/custom-resource-definitions/${var.argocd_image_tag}/applications.argoproj.io.yml", {})
+resource "kubernetes_manifest" "applications" {
+  manifest = yamldecode(templatefile("${path.module}/custom-resource-definitions/${var.argocd_image_tag}/applications.argoproj.io.yml", {}))
 }
 
-resource "k8s_manifest" "app_projects" {
-  content = templatefile("${path.module}/custom-resource-definitions/${var.argocd_image_tag}/appprojects.argoproj.io.yml", {})
+resource "kubernetes_manifest" "app_projects" {
+  manifest = yamldecode(templatefile("${path.module}/custom-resource-definitions/${var.argocd_image_tag}/appprojects.argoproj.io.yml", {}))
 }

--- a/argocd-main.tf
+++ b/argocd-main.tf
@@ -56,13 +56,16 @@ module "argocd_server" {
   cpu_limit    = local.argocd_server_limits_cpu
   memory_limit = local.argocd_server_limits_memory
 
-  replicas            = var.argocd_server_replicas
-  redis_address       = module.argocd_redis.redis_address
-  redis_port          = module.argocd_redis.redis_port
-  argocd_url          = var.argocd_url
-  cluster_cert_issuer = var.cluster_cert_issuer
-  ingress_class       = var.ingress_class
-  enable_ingress      = var.enable_ingress
+  replicas      = var.argocd_server_replicas
+  redis_address = module.argocd_redis.redis_address
+  redis_port    = module.argocd_redis.redis_port
+
+  ingress_enabled                = var.ingress_enabled
+  ingress_host                   = var.ingress_host
+  ingress_path                   = var.ingress_path
+  ingress_class_name             = var.ingress_class_name
+  ingress_annotations            = var.ingress_annotations
+  ingress_cert_issuer_annotation = var.ingress_cert_issuer_annotation
 }
 module "argocd_application_controller" {
   source = "./argocd-application-controller"

--- a/argocd-server/ingress.tf
+++ b/argocd-server/ingress.tf
@@ -1,25 +1,33 @@
-#TODO: This should be replaced with something generic
-module "argcd_ingress_route" {
-  count  = var.enable_ingress ? 1 : 0
-  source = "github.com/project-octal/terraform-octal-ingress-route"
+resource "kubernetes_ingress" "argocd_ingress_route" {
+  count = var.ingress_enabled ? 1 : 0
 
-  name        = var.name
-  namespace   = var.namespace
-  labels      = local.labels
-  cert_issuer = var.cluster_cert_issuer
-  dns_name    = var.argocd_url
-  route_rules = [
-    {
-      match_rule  = "Host(`${var.argocd_url}`)"
-      middlewares = []
-      services = [
-        {
-          name      = kubernetes_service.argocd_server.metadata.0.name
-          namespace = kubernetes_service.argocd_server.metadata.0.namespace
-          port      = 443
-          scheme    = "https"
+  metadata {
+    name        = var.name
+    namespace   = var.namespace
+    annotations = local.ingress_annotations
+    labels      = local.labels
+  }
+
+  spec {
+    ingress_class_name = var.ingress_class_name
+    rule {
+      host = var.ingress_host
+      http {
+        path {
+          path = var.ingress_path
+          backend {
+            service_name = kubernetes_service.argocd_server.metadata.0.name
+            service_port = 443
+          }
         }
-      ]
+      }
     }
-  ]
+    dynamic "tls" {
+      for_each = var.ingress_cert_issuer_annotation != null ? [1] : []
+      content {
+        hosts       = [var.ingress_host]
+        secret_name = "argocd-ingress-tls"
+      }
+    }
+  }
 }

--- a/argocd-server/locals.tf
+++ b/argocd-server/locals.tf
@@ -3,4 +3,10 @@ locals {
     "app.kubernetes.io/component" : var.component
     # Some more labels go here...
   }, var.labels)
+
+  ingress_annotations = merge(
+    var.ingress_annotations,
+    var.ingress_cert_issuer_annotation != null ? var.ingress_cert_issuer_annotation : {}
+  )
+
 }

--- a/argocd-server/variables.tf
+++ b/argocd-server/variables.tf
@@ -49,18 +49,21 @@ variable "cpu_limit" {
 variable "memory_limit" {
   type = string
 }
-variable "argocd_url" {
+variable "ingress_host" {
   type = string
 }
-variable "ingress_class" {
-  type        = string
-  description = "The ingress class that the ArgoCD ingress record should reference."
+variable "ingress_path" {
+  type = string
 }
-variable "cluster_cert_issuer" {
-  type        = string
-  description = "The cluster certificate issuer to use when creating a TLS certificate for the ingress"
-}
-
-variable "enable_ingress" {
+variable "ingress_enabled" {
   type = bool
+}
+variable "ingress_class_name" {
+  type = string
+}
+variable "ingress_annotations" {
+  type = map(string)
+}
+variable "ingress_cert_issuer_annotation" {
+  type = map(string)
 }

--- a/variables-argocd.tf
+++ b/variables-argocd.tf
@@ -36,17 +36,3 @@ variable "image_pull_policy" {
   description = "Determines when the image should be pulled prior to starting the container. `Always`: Always pull the image. | `IfNotPresent`: Only pull the image if it does not already exist on the node. | `Never`: Never pull the image"
   default     = "Always"
 }
-variable "cluster_cert_issuer" {
-  type        = string
-  description = "The cluster certificate issuer to use when creating a TLS certificate for the ingress"
-}
-variable "ingress_class" {
-  type        = string
-  description = "The ingress class that the ArgoCD ingress record should reference."
-}
-
-variable "enable_ingress" {
-  type        = bool
-  description = "If set to `true` an ingress route will be created for ArgoCD"
-  default     = true
-}

--- a/variables-configuration.tf
+++ b/variables-configuration.tf
@@ -68,12 +68,6 @@ variable "argocd_server_limits" {
     memory = null
   }
 }
-
-variable "argocd_url" {
-  type        = string
-  description = "Argo CD's externally facing base URL. Required when configuring SSO"
-  default     = "https://127.0.0.1:8080"
-}
 variable "oidc_config" {
   type = object({
     name : string,

--- a/variables-ingress.tf
+++ b/variables-ingress.tf
@@ -1,0 +1,31 @@
+
+variable "ingress_host" {
+  type        = string
+  description = "Argo CD's externally facing host. Required when configuring SSO"
+  default     = null
+}
+variable "ingress_path" {
+  type        = string
+  description = "A string or an extended POSIX regular expression as defined by IEEE Std 1003.1"
+  default     = "/"
+}
+variable "ingress_enabled" {
+  type        = bool
+  description = "If set to `true` an ingress route will be created for ArgoCD"
+  default     = true
+}
+variable "ingress_class_name" {
+  type        = string
+  description = "The ingress class that the ArgoCD ingress record should reference."
+  default     = null
+}
+variable "ingress_annotations" {
+  type        = map(string)
+  description = "A map of annotations to add to the ingress resource"
+  default     = {}
+}
+variable "ingress_cert_issuer_annotation" {
+  type        = map(string)
+  description = "The cluster certificate issuer to use when creating a TLS certificate for the ingress. needs to be set here so the tls block is defined on the ingress resource."
+  default     = {}
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.6.1"
     }
-    k8s = {
-      source  = "banzaicloud/k8s"
-      version = "0.8.0"
-    }
   }
 }


### PR DESCRIPTION
* No longer relies on the `banzaicloud/k8s` provider.
* Can be deployed alongside any ingress controller.
* Deployable without SSL (if you're into that kind of thing...)
* This module no longer relies on external modules.